### PR TITLE
Clarify access of line variable from the help menu

### DIFF
--- a/bin/pjs
+++ b/bin/pjs
@@ -8,7 +8,7 @@ var pjs     = require('../lib/pjs');
 
 var summ = "  Functions and expressions are invoked in the following order:\n" +
            "  filter, map, reduce\n\n" +
-           "  In addition to the line, all functions are passed i, its index\n" +
+           "  In addition to the line (referenced as $), all functions are passed its index (referenced as i)\n" +
            "  Built-in reduce functions: length, min, max, sum, avg, concat\n" +
            "  Custom reduce expressions accept: prev, curr, i, array";
 


### PR DESCRIPTION
I couldn't figure out how to reference the line rather than the index from the help documentation. 

Thought this might help make things clearer maybe.

Love this tool btw :-)
