### PR TITLE
Point-free support through ramda

### DIFF
--- a/bin/pjs
+++ b/bin/pjs
@@ -81,8 +81,10 @@ function getDestination() {
 
   // Pipe to each action, when set
   ['filter', 'map', 'reduce'].forEach(function(action) {
-    if (program[action]) {
-      stream = pjs[action](program[action], outputString[action]);
+    var userScript = program[action];
+    if (userScript) {
+      userScript = supportRamdaPointFree(userScript);
+      stream = pjs[action](userScript, outputString[action]);
 
       prev.pipe(stream, opts[action]);
       prev = stream;
@@ -119,4 +121,20 @@ function pipeFiles(paths, dstStream) {
   }, function () {
     dstStream.end();
   });
+}
+
+/**
+ * Append the input token as a function call if the script expression is using
+ * pointfree style
+ *
+ * @param  {string} script The user-defined script
+ * @return {string} The script with the added invocation or the original script
+ */
+function supportRamdaPointFree(script) {
+  var scriptSize = script.length;
+  // Append the invocation if the script starts with a ramda function and it
+  // doesn't include the call already
+  return ~script.indexOf('R.') && !(/\$\);?$/.test(script))
+    ? script + '($)'
+    : script;
 }

--- a/bin/pjs
+++ b/bin/pjs
@@ -131,7 +131,6 @@ function pipeFiles(paths, dstStream) {
  * @return {string} The script with the added invocation or the original script
  */
 function supportRamdaPointFree(script) {
-  var scriptSize = script.length;
   // Append the invocation if the script starts with a ramda function and it
   // doesn't include the call already
   return ~script.indexOf('R.') && !(/\$\);?$/.test(script))

--- a/lib/pjs.js
+++ b/lib/pjs.js
@@ -10,6 +10,7 @@ var inspect       = require('util').inspect;
 var utils         = require('./utils');
 var _nullObject   = utils._nullObject;
 var _             = require('lodash');
+var R             = require('ramda');
 
 /**
  * Accepts an expression to evaluate, and two booleans. The first indicates

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "async": "*",
     "commander": "*",
     "lodash": "^4.3.0",
+    "ramda": "^0.22.1",
     "split": "0.3.0",
     "streaming-json-stringify": "1.0.0"
   },


### PR DESCRIPTION
Ramda takes a functional approach, which allows tacit programming and very robust data-less scripts.

``` bash
$ echo "Returns the elements of the given \
list or string (or object with a slice method) \
from fromIndex (inclusive) to toIndex (exclusive)." | \
pjs -m 'R.slice(0, 48)'
# Returns the elements of the given list or string
```

``` bash
echo 'please-titleize-this-sentence' | \
pjs -m "R.compose(R.replace(/(^|\s)\w/g, R.toUpper), R.replace(/-/g, ' '))"
# Please Titleize This Sentence
```

And since `R.compose` only cares about unary functions, we can use any custom transform on the stack

``` bash
echo 'please-titleize-this-sentence' | \
pjs -m "R.compose(encodeURIComponent, R.replace(/(^|\s)\w/g, R.toUpper), R.replace(/-/g, ' '))"
# Please%20Titleize%20This%20Sentence
```
