### PR TITLE
Remove leading ./ from bin path

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "async": "*"
   },
   "bin": {
-    "pjs": "./bin/pjs"
+    "pjs": "bin/pjs"
   },
   "scripts": {
     "test": "mocha --recursive -R spec spec"


### PR DESCRIPTION
Removing the leading ./ from the pjs bin path allows npm to copy the script to my bin directory when using fish shell and fish node manager (fnm). Otherwise, no script was installed in bin.